### PR TITLE
클립보드 관련해서 불필요한 로직 제거

### DIFF
--- a/components/nav/navitems/LinkClipBoardMenuItem.tsx
+++ b/components/nav/navitems/LinkClipBoardMenuItem.tsx
@@ -21,12 +21,7 @@ export const LinkClipBoardMenuItem = () => {
         .share({
           text: myLink,
         })
-        .then(() => toast.success('링크가 성공적으로 공유되었습니다.'))
-        .catch(() => {
-          navigator.clipboard.writeText(myLink);
-
-          toast.success('링크가 클립보드에 복사되었어요.');
-        });
+        .then(() => toast.success('링크가 성공적으로 공유되었습니다.'));
     } else {
       await navigator.clipboard.writeText(myLink);
 


### PR DESCRIPTION
클립보드 관련해서 모바일 내부에서 클립보드 공유를 실패할 경우 복사를 재요청하는 것은 사용성에 맞지 않아서 관련 로직을 제거함. 
(클립보드 공유를 도중에 중단하는 케이스이기 때문에 복사를 재요청할 이유가 없음) 