### PR TITLE
[Feature] 닉네임 조회 API / letter 조회 API

### DIFF
--- a/app/api/letter/[userId]/route.ts
+++ b/app/api/letter/[userId]/route.ts
@@ -13,7 +13,10 @@ export async function GET(
     doc.data(),
   );
 
-  return NextResponse.json({
-    letters: lettersByWriterId,
-  });
+  return NextResponse.json(
+    {
+      letters: lettersByWriterId,
+    },
+    { status: 200, statusText: 'success' },
+  );
 }

--- a/app/api/letter/[userId]/route.ts
+++ b/app/api/letter/[userId]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { firebaseApp } from 'utils/firebaseApp';
+
+export async function GET(
+  _: unknown,
+  { params }: { params: { userId: string } },
+) {
+  const lettersByWriterIdSnapshot = await firebaseApp
+    .collection('letters')
+    .where('writerId', '==', params.userId)
+    .get();
+  const lettersByWriterId = lettersByWriterIdSnapshot.docs.map((doc) =>
+    doc.data(),
+  );
+
+  return NextResponse.json({
+    letters: lettersByWriterId,
+  });
+}

--- a/app/api/nickname/[userId]/route.ts
+++ b/app/api/nickname/[userId]/route.ts
@@ -10,6 +10,7 @@ export async function GET(
     .doc(params.userId)
     .get();
   const user = userSnapshot.data();
+  // TODO: nickname이 없을 때 처리 추가
   const nickname = user.nickname;
 
   return NextResponse.json(

--- a/app/api/nickname/[userId]/route.ts
+++ b/app/api/nickname/[userId]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { firebaseApp } from 'utils/firebaseApp';
+
+export async function GET(
+  _: unknown,
+  { params }: { params: { userId: string } },
+) {
+  const userSnapshot = await firebaseApp
+    .collection('users')
+    .doc(params.userId)
+    .get();
+  const user = userSnapshot.data();
+  const nickname = user.nickname;
+
+  return NextResponse.json(
+    { nickname },
+    { status: 200, statusText: 'success' },
+  );
+}


### PR DESCRIPTION
## :: 최근 작업 주제

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 닉네임 조회 API 구현
- letter 조회 API 구현

<br>

## :: 구현 사항 설명

- 닉네임 조회 API
  - userId를 파라미터로 받아서 해당하는 유저의 nickname을 반환합니다.
- letter 조회 API
  - userId를 파라미터로 받아서 해당하는 유저가 작성자인 letter를 모두 반환합니다.
<br/>

## :: 기타 질문 및 특이 사항

- 작성자에 따른 모든 letter 조회 / 수신자에 따른 모든 letter 조회 API를 따로 만들어야할 것 같습니다.
- userId 정보만 들어온 경우 해당 유저가 작성자인지 수신자인지 모르기 때문입니다.
- 내가 쓴 레터 보기 / 내가 받은 레터 보기 기능에 따라 API가 결정될 것으로 보입니다.
- 일단 '내가 쓴 레터 보기'에 맞는 API를 구현했고 이후에 '내가 받은 레터 보기' 기능에 맞는 API를 구현하겠습니다.

- response 타입의 컨벤션을 맞춰야할 필요성을 느꼈습니다. 의견 내주시면 참고하겠습니다.
