### PR TITLE
[Feat] 편지 공개 API

### DIFF
--- a/app/api/letter/reveal/route.ts
+++ b/app/api/letter/reveal/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { firebaseApp } from 'utils/firebaseApp';
+
+export async function POST() {
+  const lettersSnapshot = await firebaseApp.collection('letters').get();
+  const lettersDocs = lettersSnapshot.docs;
+  const letterIds = lettersDocs.map((doc) => doc.id);
+  letterIds.forEach((letterId) => {
+    const docRef = firebaseApp.collection('letters').doc(letterId);
+    docRef.update({
+      isVisible: true,
+      updatedAt: new Date(),
+    });
+  });
+  console.log(`${letterIds.length} letters are revealed! 🎉`);
+
+  return NextResponse.json('reveal all letters success', {
+    status: 200,
+    statusText: 'success',
+  });
+}

--- a/schema/Letters.ts
+++ b/schema/Letters.ts
@@ -1,5 +1,9 @@
 export class Letter {
-  contents: string;
   writerId: string;
-  reciepientId: string;
+  recipientId: string;
+  contents: string;
+  anonymousNickname: string;
+  isVisible: false;
+  createdAt: Date;
+  updatedAt: Date;
 }


### PR DESCRIPTION
## :: 최근 작업 주제

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 모든 편지를 공개하는 API입니다.

<br>

## :: 구현 사항 설명

- 실행하면 모든 letters 문서들의 `isVisible` 필드를 `true`로 변경합니다.
- 스크립트로 작성하려고 했으나 next에서의 ts-node 스크립트 사용에 대한 제한 사항들이 있는 것 같아보여서 간단히 API로 만들었습니다.
- 이후에는 `commander` 라이브러리로 cli를 만들면 좋을 것 같습니다.

<br/>

## :: 기타 질문 및 특이 사항

-
