### PR TITLE
[Fix] 레터 작성 시 잘못 수정한 isVisible 값을 올바르게 수정

### DIFF
--- a/app/api/letter/route.ts
+++ b/app/api/letter/route.ts
@@ -82,7 +82,7 @@ export async function POST(req: Request) {
     recipientId,
     contents,
     anonymousNickname,
-    isVisible: true,
+    isVisible: false,
     createdAt: operatedAt,
     updatedAt: operatedAt,
   });


### PR DESCRIPTION
## :: 최근 작업 주제

- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 레터 공개 API와 레터 작성 API를 헷갈려서 잘못 수정한 isVisible 필드 값을 다시 되돌립니다.

<br>

## :: 구현 사항 설명

- 

<br/>

## :: 기타 질문 및 특이 사항

- 신중하게 PR을 올려야겠습니다.
- 시간 관계상 못하고 있지만 코드 리뷰의 중요성을 한 번 더 느끼게 되네요!
