### PR TITLE
[Fix] 쿼카레터 버튼 라벨 수정

### DIFF
--- a/app/dashboard/[userId]/page.tsx
+++ b/app/dashboard/[userId]/page.tsx
@@ -13,6 +13,7 @@ export default async function DashBoard() {
   const session = await getServerSession(authOptions);
 
   if (!session) return redirect('/');
+  const userId = session?.user?.id;
 
   return (
     <div className="overflow-hidden h-full relative">
@@ -23,8 +24,8 @@ export default async function DashBoard() {
 
       <div className="h-[calc(100vh-48px)] p-2 bg-[#A5D8FF] text-right">
         <CountdownTimer showLabel targetDate={new Date(SCHEDULED_OPEN_DATE)} />
-        <WriteLetterButton />
-        <LetterViewerButton />
+        <WriteLetterButton userId={userId} />
+        <LetterViewerButton userId={userId} />
       </div>
     </div>
   );

--- a/components/LetterViewerButton.tsx
+++ b/components/LetterViewerButton.tsx
@@ -5,11 +5,14 @@ import { Button } from 'components/ui/button';
 import { useModal } from 'hooks/useModal';
 import { Mail } from 'lucide-react';
 import { usePathname } from 'next/navigation';
-import { useSession } from 'next-auth/react';
 
-export const LetterViewerButton = () => {
-  const { data: session } = useSession();
-  const userId = session?.user?.id;
+type LetterViewerButtonProps = {
+  userId: string;
+};
+
+export const LetterViewerButton: React.FC<LetterViewerButtonProps> = ({
+  userId,
+}) => {
   const { openModal, closeModal, isModalVisible } = useModal();
   const pathname = usePathname();
   const recipientId = pathname.match(/\/dashboard\/([a-zA-Z0-9]+)/)[1];

--- a/components/WriteLetterButton.tsx
+++ b/components/WriteLetterButton.tsx
@@ -1,16 +1,18 @@
 'use client';
 
 import { Button } from 'components/ui/button';
+import { WriteLetterModal } from 'components/WriteLetterModal';
 import { useModal } from 'hooks/useModal';
 import { Pen } from 'lucide-react';
 import { usePathname } from 'next/navigation';
-import { useSession } from 'next-auth/react';
 
-import { WriteLetterModal } from './WriteLetterModal';
+type WriteLetterButtonProps = {
+  userId: string;
+};
 
-export const WriteLetterButton = () => {
-  const { data: session } = useSession();
-  const userId = session?.user?.id;
+export const WriteLetterButton: React.FC<WriteLetterButtonProps> = ({
+  userId,
+}) => {
   const pathname = usePathname();
   const recipientId = pathname.match(/\/dashboard\/([a-zA-Z0-9]+)/)[1];
   const { closeModal, isModalVisible, openModal } = useModal();

--- a/hooks/useDynamicLineHeight.ts
+++ b/hooks/useDynamicLineHeight.ts
@@ -22,9 +22,6 @@ export const useDynamicLineHeight = ({
         const height = width * ratio;
         const newLineHeight = height / lines;
 
-        console.log('width', width);
-        console.log('newLineHeight', newLineHeight);
-
         setLineHeight(`${newLineHeight}px`);
       }
     };


### PR DESCRIPTION
## :: 최근 작업 주제

- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- [Fix] 쿼카레터 버튼 라벨 수정

<br>

## :: 구현 사항 설명

- 새로고침 했을 때, 쿼카레터 보러가기 또는 쓰러가기의 렌더링이 적절히 되지 않음
   - 예를 들어, 유저아이디와 수신자 아이디가 같을 경우 "쿼카레터 보러가기" 버튼이 떠야하지만, 쓰러가기 버튼이 뜨는 경우가 있음

<br/>

- 이를 해결하기 위해 컴포넌트 부모요소에서 props로 userId를 내려주고, 자식 컴포넌트의 props를 받아서 처리하도록 수정

## :: 기타 질문 및 특이 사항

-
