### PR TITLE
레터 내용 노출 문제를 해결

### DIFF
--- a/app/api/letter/[userId]/recieved/route.ts
+++ b/app/api/letter/[userId]/recieved/route.ts
@@ -77,10 +77,16 @@ export async function GET(
   const lettersByRecipientId = lettersByRecipientIdSnapshot.docs.map((doc) =>
     doc.data(),
   );
+  const veiledLetters = lettersByRecipientId.map((letter) => {
+    return {
+      treeIconNumber: letter.treeIconNumber,
+      anonymousNickname: letter.anonymousNickname,
+    };
+  });
 
   return NextResponse.json(
     {
-      letters: lettersByRecipientId,
+      letters: veiledLetters,
     },
     { status: 200, statusText: 'success' },
   );


### PR DESCRIPTION
## :: 최근 작업 주제

- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 레터 내용을 숨기고 `이미지 정보`와 `익명 설정 닉네임 정보`만 노출합니다.

<br>

## :: 구현 사항 설명

- 

<br/>

## :: 기타 질문 및 특이 사항

- 메시지 공개 시에 `isVisible` 필드를 변경하는 마이그레이션 작업 이전에 해당 코드를 원래대로 되돌리는 작업이 필요합니다. 배포 시 도움 요청드리겠습니다. @Geuni620 
